### PR TITLE
Default formula name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ runs:
   main: "./lib/index.js"
 inputs:
   formula-name:
-    description: The name of the Homebrew formula (defaults to the repo portion of ${{ github.repository }})
+    description: The name of the Homebrew formula (defaults to lower-cased repository name)
   homebrew-tap:
     description: The repository where the formula should be updated
     default: Homebrew/homebrew-core

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,7 @@ runs:
   main: "./lib/index.js"
 inputs:
   formula-name:
-    description: The name of the Homebrew formula
-    default: ${{ github.repository }}
+    description: The name of the Homebrew formula (defaults to the repo portion of ${{ github.repository }})
   homebrew-tap:
     description: The repository where the formula should be updated
     default: Homebrew/homebrew-core

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
 inputs:
   formula-name:
     description: The name of the Homebrew formula
-    required: true
+    default: ${{ github.repository }}
   homebrew-tap:
     description: The repository where the formula should be updated
     default: Homebrew/homebrew-core

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ export default async function(api: (token: string) => GitHub): Promise<void> {
   const externalToken = process.env.COMMITTER_TOKEN || ''
 
   const [owner, repo] = getInput('homebrew-tap', { required: true }).split('/')
-  const formulaName = getInput('formula-name', { required: true })
+  const formulaName = getInput('formula-name', { required: true }).replace(/^.*\//, '')
   const branch = getInput('base-branch')
   const filePath = `Formula/${formulaName}.rb`
   const tagName = context.ref.replace('refs/tags/', '')

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ export default async function(api: (token: string) => GitHub): Promise<void> {
   const externalToken = process.env.COMMITTER_TOKEN || ''
 
   const [owner, repo] = getInput('homebrew-tap', { required: true }).split('/')
-  const formulaName = getInput('formula-name', { required: true }).replace(/^.*\//, '')
+  const formulaName = getInput('formula-name') || context.repo.repo.toLowerCase()
   const branch = getInput('base-branch')
   const filePath = `Formula/${formulaName}.rb`
   const tagName = context.ref.replace('refs/tags/', '')


### PR DESCRIPTION
In all of the repos where I run this action, the formula-name is identical to the repository name itself. I suspect this to be a common scenario for other users as well.

This PR codifies this assumption as a convention where the formula-name is inferred from the `${{ github.repository }}` context. (And strips the leading `owner/` prefix from the name.)

(this is untested and submitted by hand wholly on github)