### PR TITLE
Add support for formula-version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ private _and_ if `COMMITTER_TOKEN` has the `public_repo` scope only.
 `GITHUB_TOKEN` will be used for verifying the SHA256 sum of the downloadable
 archive for this release.
 
+Example of manually triggered workflow:
+
+```yml
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Formula version'
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          formula-name: my_formula
+          formula-version: ${{ github.event.inputs.version }}
+          base-branch: master
+          download-url: https://example.com/foo/v${{ github.event.inputs.version }}.tar.gz
+          commit-message: {{formulaName}} {{version}}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+```
+
 ## How it works
 
 Given a Homebrew formula `Formula/my_formula.rb` in the

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Formula version'
+        description: 'Formula tag'
 
 jobs:
   homebrew:
@@ -72,14 +72,14 @@ jobs:
       - uses: mislav/bump-homebrew-formula-action@v1
         with:
           formula-name: my_formula
-          formula-version: ${{ github.event.inputs.version }}
+          tag-name: ${{ github.event.inputs.version }}
           download-url: https://example.com/foo/v${{ github.event.inputs.version }}.tar.gz
           commit-message: {{formulaName}} {{version}}
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 ```
 
-Explicitly setting `formula-version` requires `download-url` that is not a Git repository URL.
+Explicitly setting `tag-name` requires `download-url` that is not a Git repository URL.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ jobs:
         with:
           formula-name: my_formula
           formula-version: ${{ github.event.inputs.version }}
-          base-branch: master
           download-url: https://example.com/foo/v${{ github.event.inputs.version }}.tar.gz
           commit-message: {{formulaName}} {{version}}
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 ```
+
+Explicitly setting `formula-version` requires `download-url` that is not a Git repository URL.
 
 ## How it works
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ runs:
 inputs:
   formula-name:
     description: The name of the Homebrew formula (defaults to lower-cased repository name)
+  formula-version:
+    description: The version of the Homebrew formula (defaults to tag name without leading "v")
   download-url:
     description: The package download URL for the Homebrew formula (defaults to the release tarball)
   homebrew-tap:

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,8 @@ runs:
 inputs:
   formula-name:
     description: The name of the Homebrew formula (defaults to lower-cased repository name)
-  formula-version:
-    description: The version of the Homebrew formula (defaults to tag name without leading "v")
+  tag-name:
+    description: The tag name of the Homebrew formula (defaults to tag name without leading "v")
   download-url:
     description: The package download URL for the Homebrew formula (defaults to the release tarball)
   homebrew-tap:

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ export default async function (api: (token: string) => API): Promise<void> {
   const filePath = `Formula/${formulaName}.rb`
   const tagName = (process.env.GITHUB_REF as string).replace('refs/tags/', '')
   const tagSha = process.env.GITHUB_SHA as string
-  const version = tagName.replace(/^v(\d)/, '$1')
+  const version = getInput('formula-version') || tagName.replace(/^v(\d)/, '$1')
   const downloadUrl =
     getInput('download-url') ||
     tarballForRelease(contextOwner, contextRepoName, tagName)

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ export default async function (api: (token: string) => API): Promise<void> {
   const filePath = `Formula/${formulaName}.rb`
   const tagName = (process.env.GITHUB_REF as string).replace('refs/tags/', '')
   const tagSha = process.env.GITHUB_SHA as string
-  const version = getInput('formula-version') || tagName.replace(/^v(\d)/, '$1')
+  const version = getInput('tag-name') || tagName.replace(/^v(\d)/, '$1')
   const downloadUrl =
     getInput('download-url') ||
     tarballForRelease(contextOwner, contextRepoName, tagName)


### PR DESCRIPTION
Add support for `formula-version` input, that allows setting formula version without a Git tag.

Fixes #8