### PR TITLE
Add "version" Action Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ jobs:
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: my_formula
-          version: 1.0 # Override version instead of using tag
           homebrew-tap: Homebrew/homebrew-core
           base-branch: master
           download-url: https://example.com/foo/v0.1.tar.gz
@@ -55,6 +54,32 @@ You should enable `GITHUB_TOKEN` only if the repository that runs this Action is
 private _and_ if `COMMITTER_TOKEN` has the `public_repo` scope only.
 `GITHUB_TOKEN` will be used for verifying the SHA256 sum of the downloadable
 archive for this release.
+
+Non-tag based builds (override default version behavior):
+
+```yml
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          formula-name: my_formula
+          version: ${{ github.events.inputs.version }} # Override version instead of using tag
+          homebrew-tap: Homebrew/homebrew-core
+          base-branch: master
+          download-url: https://example.com/foo/v0.1.tar.gz
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+```
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ jobs:
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: my_formula
+          version: 1.0 # Override version instead of using tag
           homebrew-tap: Homebrew/homebrew-core
           base-branch: master
           download-url: https://example.com/foo/v0.1.tar.gz

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ runs:
 inputs:
   formula-name:
     description: The name of the Homebrew formula (defaults to lower-cased repository name)
+  version:
+    description: The version of the Homebrew formula (defaults to being parsed from download-url)
   download-url:
     description: The package download URL for the Homebrew formula (defaults to the release tarball)
   homebrew-tap:

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ export default async function (api: (token: string) => API): Promise<void> {
   const filePath = `Formula/${formulaName}.rb`
   const tagName = (process.env.GITHUB_REF as string).replace('refs/tags/', '')
   const tagSha = process.env.GITHUB_SHA as string
-  const version = tagName.replace(/^v(\d)/, '$1')
+  const version = getInput('version') || tagName.replace(/^v(\d)/, '$1')
   const downloadUrl =
     getInput('download-url') ||
     tarballForRelease(contextOwner, contextRepoName, tagName)


### PR DESCRIPTION
* Add the ability to override the default `version` derivation
* Updated documentation

Replaces #9 since no action being taken.
Closes #8