### PR TITLE
Avoid using optional chaining

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -18,7 +18,7 @@ export default function (
     auth: `token ${token}`,
     log: {
       info(msg: string) {
-        if (options?.logRequests === false) return
+        if (options && options.logRequests === false) return
         return console.info(msg)
       },
       debug(msg: string) {


### PR DESCRIPTION
Fixes https://github.com/mislav/bump-homebrew-formula-action/issues/25

Optional chaining is available from Node.js v14. However, this action is running in Node.js v12, so it raises an error like `SyntaxError: Unexpected token '.'`

https://github.com/mislav/bump-homebrew-formula-action/blob/0104f1216538046c52b567142d310cc944af198a/action.yml#L5

This is introduced in https://github.com/mislav/bump-homebrew-formula-action/commit/e1f3c487f88d11d7d711ab43ec18d2d7439643f0