### PR TITLE
deps: update to use node v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
-          cache: 'npm'
+          node-version: "16.x"
+          cache: "npm"
       - run: npm ci
       - name: Run tests
         run: |

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: bump-homebrew-formula
-description: 'Bump Homebrew formula after a new release'
-author: '@mislav'
+description: "Bump Homebrew formula after a new release"
+author: "@mislav"
 runs:
-  using: node12
-  main: './lib/index.js'
+  using: node16
+  main: "./lib/index.js"
 inputs:
   formula-name:
     description: The name of the Homebrew formula (defaults to lower-cased repository name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@octokit/request-error": "^2.1.0"
       },
       "devDependencies": {
-        "@types/node": "^14.14.25",
+        "@types/node": "^16.11.7",
         "@types/node-fetch": "^2.5.8",
         "@typescript-eslint/eslint-plugin": "^3.7.1",
         "@typescript-eslint/parser": "^3.7.1",
-        "@vercel/ncc": "^0.27.0",
+        "@vercel/ncc": "^0.33.4",
         "ava": "^3.11.0",
         "eslint": "^7.5.0",
         "eslint-config-prettier": "^6.11.0",
@@ -381,9 +381,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.2.tgz",
-      "integrity": "sha512-fqtSN5xn/bBzDxMT77C1rJg6CsH/R49E7qsGuvdPJa20HtV5zSTuLJPNfnlyVH3wauKnkHdLggTVkOW/xP9oQg==",
+      "version": "16.11.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.33.tgz",
+      "integrity": "sha512-0PJ0vg+JyU0MIan58IOIFRtSvsb7Ri+7Wltx2qAg94eMOrpg4+uuP3aUHCpxXc1i0jCXiC+zIamSZh3l9AbcQA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.27.0.tgz",
-      "integrity": "sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
+      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -4798,9 +4798,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.2.tgz",
-      "integrity": "sha512-fqtSN5xn/bBzDxMT77C1rJg6CsH/R49E7qsGuvdPJa20HtV5zSTuLJPNfnlyVH3wauKnkHdLggTVkOW/xP9oQg==",
+      "version": "16.11.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.33.tgz",
+      "integrity": "sha512-0PJ0vg+JyU0MIan58IOIFRtSvsb7Ri+7Wltx2qAg94eMOrpg4+uuP3aUHCpxXc1i0jCXiC+zIamSZh3l9AbcQA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -4891,9 +4891,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.27.0.tgz",
-      "integrity": "sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
+      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "@octokit/request-error": "^2.1.0"
   },
   "devDependencies": {
-    "@types/node": "^14.14.25",
+    "@types/node": "^16.11.7",
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
-    "@vercel/ncc": "^0.27.0",
+    "@vercel/ncc": "^0.33.4",
     "ava": "^3.11.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12.

This is supported on all Actions Runners v2.285.0 or later.

---

should be major version bump per PR merge
