### PR TITLE
chore: use `/archive/refs/tags/${tagName}.tar.gz` rather than `/archive/${tagName}.tar.gz`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Formula parameters:
 
 * `download-url`: the package download URL for the Homebrew formula.
 
-  Defaults to `https://github.com/OWNER/REPO/archive/<tag-name>.tar.gz`, where `OWNER/REPO` is the repository that is running the Actions workflow.
+  Defaults to `https://github.com/OWNER/REPO/archive/refs/tags/<tag-name>.tar.gz`, where `OWNER/REPO` is the repository that is running the Actions workflow.
 
 * `download-sha256`: the SHA256 checksum of the archive at `download-url`.
   Defaults to calculating the checksum by fetching the archive at run time.
@@ -126,7 +126,7 @@ Given a Homebrew formula `Formula/my_formula.rb` in the
 
 ```rb
 class MyFormula < Formula
-  url "https://github.com/me/myproject/archive/v1.2.3.tar.gz"
+  url "https://github.com/me/myproject/archive/refs/tags/v1.2.3.tar.gz"
   sha256 "<OLDSHA>"
   # ...
 end
@@ -137,7 +137,7 @@ the formula will be updated to:
 
 ```rb
 class MyFormula < Formula
-  url "https://github.com/me/myproject/archive/v2.0.0.tar.gz"
+  url "https://github.com/me/myproject/archive/refs/tags/v2.0.0.tar.gz"
   sha256 "<NEWSHA>"
   # ...
 end

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -60,6 +60,7 @@ test('prepareEdit()', async (t) => {
     },
   }
 
+  process.env['GITHUB_REPOSITORY'] = 'Homebrew/homebrew-core'
   process.env['INPUT_HOMEBREW-TAP'] = 'Homebrew/homebrew-core'
   process.env['INPUT_COMMIT-MESSAGE'] = 'Upgrade {{formulaName}} to {{version}}'
 

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -60,7 +60,6 @@ test('prepareEdit()', async (t) => {
     },
   }
 
-  process.env['GITHUB_REPOSITORY'] = 'Homebrew/homebrew-core'
   process.env['INPUT_HOMEBREW-TAP'] = 'Homebrew/homebrew-core'
   process.env['INPUT_COMMIT-MESSAGE'] = 'Upgrade {{formulaName}} to {{version}}'
 
@@ -73,7 +72,7 @@ test('prepareEdit()', async (t) => {
           status: 301,
           headers: {
             Location:
-              'https://github.com/mislav/bump-homebrew-formula-action/archive/refs/tags/v1.9.tar.gz',
+              'https://github.com/mislav/bump-homebrew-formula-action/archive/v1.9.tar.gz',
           },
         })
       )
@@ -101,7 +100,7 @@ test('prepareEdit()', async (t) => {
   t.is(
     `
     class MyProgram < Formula
-      url "https://github.com/OWNER/REPO/archive/refs/tags/v0.8.2.tar.gz"
+      url "https://github.com/OWNER/REPO/archive/v0.8.2.tar.gz"
       sha256 "c036fbc44901b266f6d408d6ca36ba56f63c14cc97994a935fb9741b55edee83"
       head "git://example.com/repo.git",
         revision: "GITSHA"

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -67,7 +67,7 @@ test('prepareEdit() homebrew-core', async (t) => {
   // FIXME: this tests results in a live HTTP request. Figure out how to stub the `stream()` method in
   // calculate-download-checksum.
   const stubbedFetch = function (url: string) {
-    if (url == 'https://api.github.com/repos/OWNER/REPO/tarball/v0.8.2') {
+    if (url == 'https://api.github.com/repos/OWNER/REPO/tarball/refs%2Ftags%2Fv0.8.2') {
       return Promise.resolve(
         new Response('', {
           status: 301,
@@ -101,7 +101,7 @@ test('prepareEdit() homebrew-core', async (t) => {
   t.is(
     `
     class MyProgram < Formula
-      url "https://github.com/OWNER/REPO/archive/v0.8.2.tar.gz"
+      url "https://github.com/OWNER/REPO/archive/refs/tags/v0.8.2.tar.gz"
       sha256 "c036fbc44901b266f6d408d6ca36ba56f63c14cc97994a935fb9741b55edee83"
       head "git://example.com/repo.git",
         revision: "GITSHA"

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -67,7 +67,10 @@ test('prepareEdit() homebrew-core', async (t) => {
   // FIXME: this tests results in a live HTTP request. Figure out how to stub the `stream()` method in
   // calculate-download-checksum.
   const stubbedFetch = function (url: string) {
-    if (url == 'https://api.github.com/repos/OWNER/REPO/tarball/refs%2Ftags%2Fv0.8.2') {
+    if (
+      url ==
+      'https://api.github.com/repos/OWNER/REPO/tarball/refs%2Ftags%2Fv0.8.2'
+    ) {
       return Promise.resolve(
         new Response('', {
           status: 301,

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -72,7 +72,7 @@ test('prepareEdit()', async (t) => {
           status: 301,
           headers: {
             Location:
-              'https://github.com/mislav/bump-homebrew-formula-action/archive/v1.9.tar.gz',
+              'https://github.com/mislav/bump-homebrew-formula-action/archive/refs/tags/v1.9.tar.gz',
           },
         })
       )
@@ -100,7 +100,7 @@ test('prepareEdit()', async (t) => {
   t.is(
     `
     class MyProgram < Formula
-      url "https://github.com/OWNER/REPO/archive/v0.8.2.tar.gz"
+      url "https://github.com/OWNER/REPO/archive/refs/tags/v0.8.2.tar.gz"
       sha256 "c036fbc44901b266f6d408d6ca36ba56f63c14cc97994a935fb9741b55edee83"
       head "git://example.com/repo.git",
         revision: "GITSHA"

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ export async function prepareEdit(
     replacements.set(
       'sha256',
       getInput('download-sha256') ||
-      (await calculateDownloadChecksum(sameRepoClient, downloadUrl, 'sha256'))
+        (await calculateDownloadChecksum(sameRepoClient, downloadUrl, 'sha256'))
     )
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ function tarballForRelease(
   repo: string,
   tagName: string
 ): string {
-  return `https://github.com/${owner}/${repo}/archive/${tagName}.tar.gz`
+  return `https://github.com/${owner}/${repo}/archive/refs/tags/${tagName}.tar.gz`
 }
 
 export function commitForRelease(
@@ -116,7 +116,7 @@ export async function prepareEdit(
     replacements.set(
       'sha256',
       getInput('download-sha256') ||
-        (await calculateDownloadChecksum(sameRepoClient, downloadUrl, 'sha256'))
+      (await calculateDownloadChecksum(sameRepoClient, downloadUrl, 'sha256'))
     )
   }
 

--- a/src/version-test.ts
+++ b/src/version-test.ts
@@ -3,7 +3,7 @@ import { fromUrl } from './version'
 
 test('fromUrl()', (t) => {
   t.is(
-    fromUrl('https://github.com/me/myproject/archive/v1.2.3.tar.gz'),
+    fromUrl('https://github.com/me/myproject/archive/refs/tags/v1.2.3.tar.gz'),
     'v1.2.3'
   )
   t.is(


### PR DESCRIPTION
We should use `/archive/refs/tags/${tagName}.tar.gz` rather than `/archive/${tagName}.tar.gz` for the two reasons:
- `/archive/refs/tags/${tagName}.tar.gz` is the default url when grabbing from the UI
- also it would remove the confusion/issue when there is a name clash between tagName and a branch name.