### PR TITLE
(docs): use environment files instead of set-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
       - name: Extract version
         id: extract-version
         run: |
-          printf "::set-output name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}"
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - uses: mislav/bump-homebrew-formula-action@v2
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:


### PR DESCRIPTION
Thanks for creating a great workflow!

## What this PR changes
This PR changes usage example in the README.md to use environment files instead of `set-output` because [`set-output` is deprecated.](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

close #56

## What I've tested
I have confirmed that [this change does not change the original behavior](https://github.com/kyu08/fzf-make/actions/runs/5784342357/job/15674849274) in my project.

The yaml file I used for this test is [this](https://github.com/kyu08/fzf-make/blob/fbe8fdb67dd2cc0aa13310abd2b5d7e9d2de56ea/.github/workflows/release.yml#L1).

<img width="1046" alt="image" src="https://github.com/mislav/bump-homebrew-formula-action/assets/49891479/eca993c9-0d64-49fa-9738-c59f9b69911b">
