### PR TITLE
Fix formula path after sharding of homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:
           formula-name: my_formula
-          formula-path: Formula/my_formula.rb
+          formula-path: Formula/m/my_formula.rb
           homebrew-tap: Homebrew/homebrew-core
           base-branch: master
           download-url: https://example.com/foo/${{ steps.extract-version.outputs.tag-name }}.tar.gz
@@ -72,7 +72,7 @@ Formula parameters:
   lower-cased repository name.
 
 * `formula-path`: the relative path of the Homebrew formula file to edit within the `homebrew-tap` repository. Defaults to
-  `Formula/<formula-name>.rb`.
+  `Formula/<letter>/<formula-name>.rb` for homebrew-core formulae and `Formula/<formula-name>.rb` otherwise.
 
 * `tag-name`: the git tag name to bump the formula to. Defaults to the
   currently pushed tag.

--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -50,7 +50,7 @@ test('commitForRelease()', (t) => {
   )
 })
 
-test('prepareEdit()', async (t) => {
+test('prepareEdit() homebrew-core', async (t) => {
   const ctx = {
     sha: 'TAGSHA',
     ref: 'refs/tags/v0.8.2',
@@ -60,6 +60,7 @@ test('prepareEdit()', async (t) => {
     },
   }
 
+  process.env['GITHUB_REPOSITORY'] = 'monalisa/hello-world'
   process.env['INPUT_HOMEBREW-TAP'] = 'Homebrew/homebrew-core'
   process.env['INPUT_COMMIT-MESSAGE'] = 'Upgrade {{formulaName}} to {{version}}'
 
@@ -85,7 +86,7 @@ test('prepareEdit()', async (t) => {
   t.is(opts.owner, 'Homebrew')
   t.is(opts.repo, 'homebrew-core')
   t.is(opts.branch, '')
-  t.is(opts.filePath, 'Formula/repo.rb')
+  t.is(opts.filePath, 'Formula/r/repo.rb')
   t.is(opts.commitMessage, 'Upgrade repo to 0.8.2')
 
   const oldFormula = `
@@ -108,4 +109,34 @@ test('prepareEdit()', async (t) => {
   `,
     opts.replace(oldFormula)
   )
+})
+
+test('prepareEdit() non-homebrew-core', async (t) => {
+  const ctx = {
+    sha: 'TAGSHA',
+    ref: 'refs/tags/v0.8.2',
+    repo: {
+      owner: 'OWNER',
+      repo: 'REPO',
+    },
+  }
+
+  process.env['GITHUB_REPOSITORY'] = 'monalisa/hello-world'
+  process.env['INPUT_HOMEBREW-TAP'] = 'myorg/homebrew-utils'
+  process.env['INPUT_COMMIT-MESSAGE'] = 'Upgrade {{formulaName}} to {{version}}'
+  process.env['INPUT_DOWNLOAD-SHA256'] = 'MOCK-SHA-256'
+
+  const apiClient = api('ATOKEN', {
+    fetch: function (url: string) {
+      throw url
+    },
+    logRequests: false,
+  })
+
+  const opts = await prepareEdit(ctx, apiClient, apiClient)
+  t.is(opts.owner, 'myorg')
+  t.is(opts.repo, 'homebrew-utils')
+  t.is(opts.branch, '')
+  t.is(opts.filePath, 'Formula/repo.rb')
+  t.is(opts.commitMessage, 'Upgrade repo to 0.8.2')
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,17 @@ function tarballForRelease(
   return `https://github.com/${owner}/${repo}/archive/${tagName}.tar.gz`
 }
 
+function formulaPath(owner: string, repo: string, formulaName: string): string {
+  if (
+    owner.toLowerCase() == 'homebrew' &&
+    repo.toLowerCase() == 'homebrew-core'
+  ) {
+    // respect formula sharding structure in `Homebrew/homebrew-core`
+    return `Formula/${formulaName.charAt(0)}/${formulaName}.rb`
+  }
+  return `Formula/${formulaName}.rb`
+}
+
 export function commitForRelease(
   messageTemplate: string,
   params: { [key: string]: string } = {}
@@ -82,7 +93,8 @@ export async function prepareEdit(
   }
   const formulaName = getInput('formula-name') || ctx.repo.repo.toLowerCase()
   const branch = getInput('base-branch')
-  const filePath = getInput('formula-path') || `Formula/${formulaName.charAt(0)}/${formulaName}.rb`
+  const filePath =
+    getInput('formula-path') || formulaPath(owner, repo, formulaName)
   const version = tagName.replace(/^v(\d)/, '$1')
   const downloadUrl =
     getInput('download-url') ||

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ export async function prepareEdit(
   }
   const formulaName = getInput('formula-name') || ctx.repo.repo.toLowerCase()
   const branch = getInput('base-branch')
-  const filePath = getInput('formula-path') || `Formula/${formulaName}.rb`
+  const filePath = getInput('formula-path') || `Formula/${formulaName.charAt(0)}/${formulaName}.rb`
   const version = tagName.replace(/^v(\d)/, '$1')
   const downloadUrl =
     getInput('download-url') ||


### PR DESCRIPTION
### Description

With homebrew-core sharding formula into directories named after the first letter of the formula, this action no longer works without configuring `formula-path`. This is described in https://github.com/mislav/bump-homebrew-formula-action/issues/58.

I think this PR resolves the issue but interpolating the first letter of the `formulaName` into the path. This isn't unicode safe but I can't see any reason that homebrew would start to allow that.

Cheers.