### PR TITLE
feat: bump to use node20 runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           cache: "npm"
       - run: npm ci
       - name: Run tests

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: bump-homebrew-formula
 description: "Bump Homebrew formula after a new release"
 author: "@mislav"
 runs:
-  using: node16
+  using: node20
   main: "./lib/index.js"
 inputs:
   formula-name:


### PR DESCRIPTION
Node12 was deleted from runner. Node20 was added to Actions Runner on v2.308.0.
Node16 has en end of life on 11 Sep 2023.

This PR updates the default runtime to node20, rather then node16

relates to https://github.com/actions/runner/pull/2732

---


needs a major version release after the PR merge

cc @mislav 

