### PR TITLE
Fix extracting version tags from GitHub download URLs

### DIFF
--- a/src/version-test.ts
+++ b/src/version-test.ts
@@ -1,17 +1,41 @@
 import test from 'ava'
-import { fromUrl } from './version'
+import { compare, fromUrl } from './version'
 
 test('fromUrl()', (t) => {
-  t.is(
-    fromUrl('https://github.com/me/myproject/archive/refs/tags/v1.2.3.tar.gz'),
-    'v1.2.3'
-  )
-  t.is(
-    fromUrl(
-      'https://github.com/me/myproject/releases/download/v1.2.3/file.tgz'
-    ),
-    'v1.2.3'
-  )
-  t.is(fromUrl('http://myproject.net/download/v1.2.3.tgz'), 'v1.2.3')
-  t.is(fromUrl('https://example.com/v1.2.3.zip'), 'v1.2.3')
+  const cases = new Map<string, string>([
+    [
+      'https://github.com/me/myproject/archive/refs/tags/v1.2.3.tar.gz',
+      'v1.2.3',
+    ],
+    [
+      'https://github.com/me/myproject/releases/download/v1.2.3/file.tgz',
+      'v1.2.3',
+    ],
+    ['http://myproject.net/download/v1.2.3.tgz', 'v1.2.3'],
+    ['https://example.com/v1.2.3.zip', 'v1.2.3'],
+    [
+      'https://github.com/SmartThingsCommunity/smartthings-cli/releases/download/%40smartthings%2Fcli%401.7.0/smartthings-macos-arm64.tar.gz',
+      '@smartthings/cli@1.7.0',
+    ],
+    [
+      'https://github.com/SmartThingsCommunity/smartthings-cli/releases/download/@smartthings/cli@1.7.0/smartthings-macos-x64.tar.gz',
+      '@smartthings/cli@1.7.0',
+    ],
+    [
+      'https://github.com/orf/gping/archive/refs/tags/gping-v1.14.0.tar.gz',
+      'gping-v1.14.0',
+    ],
+  ])
+  for (const item of cases) {
+    t.is(fromUrl(item[0]), item[1], item[0])
+  }
+})
+
+test('compare()', (t) => {
+  t.is(compare('v1.2.0', 'v1.2.1'), -1)
+  t.is(compare('v1.2.0', 'v1.1.9.0'), 1)
+  t.is(compare('gping-v1.13', 'gping-v1.14.0'), -1)
+  t.is(compare('@smartthings/cli@1.7.0', '@smartthings/cli@1.7.0-rc2'), 1)
+  t.is(compare('@smartthings/cli@1.7.0', '@smartthings/cli@1.7.0'), 0)
+  t.is(compare('@smartthings/cli@1.7.0', '@smartthings/cli@1.10.0'), -1)
 })

--- a/src/version.ts
+++ b/src/version.ts
@@ -29,13 +29,12 @@ export function compare(v1: string, v2: string): -1 | 0 | 1 {
 }
 
 const ghDownloadRE =
-  /^https:\/\/github.com\/[^/]+\/[^/]+\/releases\/download\/([^/]+)/
+  /^https:\/\/github.com\/[^/]+\/[^/]+\/releases\/download\/(.+)\/[^/]+$/
 
-// TODO: https://github.com/Homebrew/brew/blob/675e38b5e4fe0290fa05f65af23c9a82d3e7cc76/Library/Homebrew/version.rb#L225-L363
 export function fromUrl(url: string): string {
   const downloadMatch = url.match(ghDownloadRE)
   if (downloadMatch) {
-    return downloadMatch[1]
+    return decodeURIComponent(downloadMatch[1])
   }
   return basename(url).replace(/\.(tar\.gz|tgz|zip)$/, '')
 }


### PR DESCRIPTION
Fixes https://github.com/mislav/bump-homebrew-formula-action/issues/18