### PR TITLE
Fix calculating checksum for resource at download URL

### DIFF
--- a/src/main-test.ts
+++ b/src/main-test.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import api from './api'
 import { commitForRelease, prepareEdit } from './main'
-import { Response } from 'node-fetch'
 
 test('commitForRelease()', (t) => {
   t.is(
@@ -53,10 +52,10 @@ test('commitForRelease()', (t) => {
 test('prepareEdit() homebrew-core', async (t) => {
   const ctx = {
     sha: 'TAGSHA',
-    ref: 'refs/tags/v0.8.2',
+    ref: 'refs/tags/v1.9',
     repo: {
-      owner: 'OWNER',
-      repo: 'REPO',
+      owner: 'mislav',
+      repo: 'bump-homebrew-formula-action',
     },
   }
 
@@ -64,33 +63,19 @@ test('prepareEdit() homebrew-core', async (t) => {
   process.env['INPUT_HOMEBREW-TAP'] = 'Homebrew/homebrew-core'
   process.env['INPUT_COMMIT-MESSAGE'] = 'Upgrade {{formulaName}} to {{version}}'
 
-  // FIXME: this tests results in a live HTTP request. Figure out how to stub the `stream()` method in
-  // calculate-download-checksum.
+  // FIXME: this tests results in a live HTTP request. Figure out how to stub
+  // `stream()` and `resolveRedirect()` methods in calculate-download-checksum.
   const stubbedFetch = function (url: string) {
-    if (
-      url ==
-      'https://api.github.com/repos/OWNER/REPO/tarball/refs%2Ftags%2Fv0.8.2'
-    ) {
-      return Promise.resolve(
-        new Response('', {
-          status: 301,
-          headers: {
-            Location:
-              'https://github.com/mislav/bump-homebrew-formula-action/archive/v1.9.tar.gz',
-          },
-        })
-      )
-    }
     throw url
   }
-  const apiClient = api('ATOKEN', { fetch: stubbedFetch, logRequests: false })
+  const apiClient = api('', { fetch: stubbedFetch, logRequests: false })
 
   const opts = await prepareEdit(ctx, apiClient, apiClient)
   t.is(opts.owner, 'Homebrew')
   t.is(opts.repo, 'homebrew-core')
   t.is(opts.branch, '')
-  t.is(opts.filePath, 'Formula/r/repo.rb')
-  t.is(opts.commitMessage, 'Upgrade repo to 0.8.2')
+  t.is(opts.filePath, 'Formula/b/bump-homebrew-formula-action.rb')
+  t.is(opts.commitMessage, 'Upgrade bump-homebrew-formula-action to 1.9')
 
   const oldFormula = `
     class MyProgram < Formula
@@ -104,7 +89,7 @@ test('prepareEdit() homebrew-core', async (t) => {
   t.is(
     `
     class MyProgram < Formula
-      url "https://github.com/OWNER/REPO/archive/refs/tags/v0.8.2.tar.gz"
+      url "https://github.com/mislav/bump-homebrew-formula-action/archive/refs/tags/v1.9.tar.gz"
       sha256 "c036fbc44901b266f6d408d6ca36ba56f63c14cc97994a935fb9741b55edee83"
       head "git://example.com/repo.git",
         revision: "GITSHA"


### PR DESCRIPTION
Octokit has broken `redirect: 'manual'`, so avoid using Octokit for intercepting HTTP redirects.

Fixes #76
Ref. https://github.com/octokit/request.js/pull/636