### PR TITLE
Update readme with push-to caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Repository parameters:
 - `homebrew-tap`: the full GitHub repository name (in the `NAME/OWNER` format) where the Homebrew formula should be updated. Defaults
   to `Homebrew/homebrew-core`.
 
-- `push-to`: a specific fork of `homebrew-tap` where the edit should be pushed to. Defaults to creating or reusing a personal fork of the owner of COMMITTER_TOKEN.
+- `push-to`: a specific fork of `homebrew-tap` where the edit should be pushed to.
+  Defaults to creating or reusing a personal fork of the owner of COMMITTER_TOKEN.
+  Avoid using an organization-owned fork, as this breaks Homebrew's automation.
 
 - `base-branch`: the branch name in the `homebrew-tap` repository where the
   formula should be updated. Defaults to the main branch of the repository.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Repository parameters:
 
 - `push-to`: a specific fork of `homebrew-tap` where the edit should be pushed to.
   Defaults to creating or reusing a personal fork of the owner of COMMITTER_TOKEN.
-  Avoid using an organization-owned fork, as this breaks Homebrew's automation.
+  Note: Avoid using an organization-owned fork, as this
+  [breaks Homebrew's automation](https://github.com/mislav/bump-homebrew-formula-action/pull/150).
 
 - `base-branch`: the branch name in the `homebrew-tap` repository where the
   formula should be updated. Defaults to the main branch of the repository.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Repository parameters:
 
 - `push-to`: a specific fork of `homebrew-tap` where the edit should be pushed to.
   Defaults to creating or reusing a personal fork of the owner of COMMITTER_TOKEN.
-  Note: Avoid using an organization-owned fork, as this
-  [breaks Homebrew's automation](https://github.com/mislav/bump-homebrew-formula-action/pull/150).
+  (Note: avoid using an organization-owned fork, as that
+  [breaks automation for `homebrew-core`](https://github.com/foxglove/mcap/issues/1063)).
 
 - `base-branch`: the branch name in the `homebrew-tap` repository where the
   formula should be updated. Defaults to the main branch of the repository.


### PR DESCRIPTION
We were using `push-to` with an organization-owned fork, but a Homebrew maintainer said that this breaks their automation, and that we must submit PRs from an individual fork.

See: https://github.com/foxglove/mcap/issues/1063

I added a note about this to the readme to avoid future headaches.