### PR TITLE
Fix Node process hanging indefinitely due to HTTP redirect handling

### DIFF
--- a/src/calculate-download-checksum-test.ts
+++ b/src/calculate-download-checksum-test.ts
@@ -4,6 +4,9 @@ import {
   parseArchiveUrl,
   parseReleaseDownloadUrl,
 } from './calculate-download-checksum.js'
+import stream from './calculate-download-checksum.js'
+import { createServer } from 'http'
+import api from './api.js'
 
 test('calculate-download-checksum parseArchiveUrl', (t) => {
   const tests = [
@@ -80,4 +83,45 @@ test('calculate-download-checksum parseReleaseDownloadUrl', (t) => {
     t.is(tt.wants.tagname, asset.tagname)
     t.is(tt.wants.name, asset.name)
   })
+})
+
+test('calculate-download-checksum stream', async (t) => {
+  const server = createServer((req, res) => {
+    if (req.url == '/redirect') {
+      res.writeHead(302, { location: `http://${req.headers['host']}/download` })
+      res.end()
+    } else if (req.url == '/download') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('hello world')
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
+  })
+
+  // start a test server on a randomly available port
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (typeof address !== 'object' || address == null) {
+    t.fail('Could not get server address')
+    return
+  }
+
+  const apiClient = api('ATOKEN')
+  const shasum = await stream(
+    apiClient,
+    `http://localhost:${address.port}/redirect`,
+    'sha256'
+  )
+  t.is(
+    shasum,
+    'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9' // sha256 of 'hello world'
+  )
+
+  t.teardown(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+  )
 })

--- a/src/calculate-download-checksum.ts
+++ b/src/calculate-download-checksum.ts
@@ -18,13 +18,14 @@ function stream(
     ;(url.protocol == 'https:' ? HTTPS : HTTP)(url, { headers }, (res) => {
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
         const loc = res.headers['location']
-        if (loc == null) throw `HTTP ${res.statusCode} but no Location header`
         res.resume()
+        if (loc == null) throw `HTTP ${res.statusCode} but no Location header`
         const nextURL = new URL(loc)
         log(nextURL)
         resolve(stream(nextURL, headers, cb))
         return
       } else if (res.statusCode && res.statusCode >= 400) {
+        res.resume()
         throw new Error(`HTTP ${res.statusCode}`)
       }
       res.on('data', (d) => cb(d))


### PR DESCRIPTION
In case calculating the SHA checksum of the resource at `download-url` encountered HTTP redirects, and the resource is _not_ hosted at github.com, HTTP responses were not being properly cleaned up and thus could cause the Node process to hang indefinitely even after the main function had already finished.

Fixes https://github.com/mislav/bump-homebrew-formula-action/issues/243