### PR TITLE
Disable source map register when generating the `lib/index.js` bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rm -rf lib && ncc build src/run.ts -o lib --source-map",
+    "build": "rm -rf lib && ncc build src/run.ts -o lib --source-map --no-source-map-register",
     "lint": "eslint .",
     "test": "tsc --sourceMap && ava"
   },


### PR DESCRIPTION
By default, ncc with source map support generates a file called `sourcemap-register.cjs` that is imported from the main bundle. I am not familiar with the purpose of this extra implementation file, but it seems to me that this might be a compatibility layer meant for older versions of Node that did not have full support for source maps. Apparently, I never checked this extra file to version control and it caused import problems in the v3.3 release.

Since this action runs under Node 20 that has full support for source maps, I'm guessing that this compatibility later isn't needed anymore.

Fixes https://github.com/mislav/bump-homebrew-formula-action/issues/245