### PR TITLE
Print formula bump PR in Job Summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prepare": "npm run build",
     "build": "rm -rf lib && ncc build src/run.ts -o lib --source-map --no-source-map-register",
     "lint": "eslint .",
     "test": "tsc --sourceMap && ava"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { getInput, getBooleanInput } from '@actions/core'
+import { getInput, getBooleanInput, summary } from '@actions/core'
 import type { API } from './api.js'
 import editGitHubBlob from './edit-github-blob.js'
 import { Options as EditOptions } from './edit-github-blob.js'
@@ -45,6 +45,7 @@ export default async function (api: (token: string) => API): Promise<void> {
     process.env.GITHUB_TOKEN || process.env.COMMITTER_TOKEN || ''
   const externalToken = process.env.COMMITTER_TOKEN || ''
 
+  summary.addHeading('Bump Homebrew formula')
   const options = await prepareEdit(
     context,
     api(internalToken),
@@ -52,6 +53,9 @@ export default async function (api: (token: string) => API): Promise<void> {
   )
   const createdUrl = await editGitHubBlob(options)
   console.log(createdUrl)
+  summary.addLink(createdUrl, createdUrl)
+  summary.addSeparator()
+  summary.write()
 }
 
 type Context = {
@@ -147,6 +151,8 @@ export async function prepareEdit(
     formulaName,
     version,
   })
+
+  summary.addRaw(`🍺 Bumping ${formulaName} to ${tagName} `)
 
   return {
     apiClient: crossRepoClient,


### PR DESCRIPTION
A very common step that I need to do after running this action is to go to the PR just opened. (Usually, to merge it 😄 )

It's helpful that the PR link is printed to the log. However, surfacing this information in a Job Summary would be even more helpful, imo. It's not surrounded by other verbose log output, nor does it require clicking into the job, and again to expand the step.

The summary is printed and rendered as GFM markdown right from the main workflow run top page.

Screenshot taken from a test run:

<img width="1126" height="870" alt="image" src="https://github.com/user-attachments/assets/99e8db14-99e3-4116-b96d-de309ec8b36b" />

(The trailing horizontal-rule was added in case subsequent steps print to the summary as well, as is the case in my workflow with the @step-security Harden-Runner action.)