### PR TITLE
Accept any 3xx redirect when resolving tarball URLs

### DIFF
--- a/src/calculate-download-checksum-test.ts
+++ b/src/calculate-download-checksum-test.ts
@@ -92,6 +92,9 @@ test('calculate-download-checksum resolveRedirect follows HTTP 303', async (t) =
     if (req.method == 'HEAD' && req.url == '/tarball') {
       res.writeHead(303, { location: 'https://codeload.example.com/tar.gz' })
       res.end()
+    } else if (req.method == 'HEAD' && req.url == '/tarball-relative') {
+      res.writeHead(303, { location: '/download/tar.gz' })
+      res.end()
     } else {
       res.writeHead(404)
       res.end()
@@ -99,6 +102,12 @@ test('calculate-download-checksum resolveRedirect follows HTTP 303', async (t) =
   })
 
   await new Promise<void>((resolve) => server.listen(0, resolve))
+  t.teardown(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+  )
   const address = server.address()
   if (typeof address !== 'object' || address == null) {
     t.fail('Could not get server address')
@@ -113,11 +122,14 @@ test('calculate-download-checksum resolveRedirect follows HTTP 303', async (t) =
   )
   t.is(url.href, 'https://codeload.example.com/tar.gz')
 
-  t.teardown(
-    () =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve())
-      })
+  const relativeUrl = await resolveRedirect(
+    apiClient,
+    new URL(`http://localhost:${address.port}/tarball-relative`),
+    false
+  )
+  t.is(
+    relativeUrl.href,
+    `http://localhost:${address.port}/download/tar.gz`
   )
 })
 

--- a/src/calculate-download-checksum-test.ts
+++ b/src/calculate-download-checksum-test.ts
@@ -3,6 +3,7 @@ import { URL } from 'url'
 import {
   parseArchiveUrl,
   parseReleaseDownloadUrl,
+  resolveRedirect,
 } from './calculate-download-checksum.js'
 import stream from './calculate-download-checksum.js'
 import { createServer } from 'http'
@@ -83,6 +84,41 @@ test('calculate-download-checksum parseReleaseDownloadUrl', (t) => {
     t.is(tt.wants.tagname, asset.tagname)
     t.is(tt.wants.name, asset.name)
   })
+})
+
+test('calculate-download-checksum resolveRedirect follows HTTP 303', async (t) => {
+  // GitHub's tarball API responds to HEAD requests with HTTP 303
+  const server = createServer((req, res) => {
+    if (req.method == 'HEAD' && req.url == '/tarball') {
+      res.writeHead(303, { location: 'https://codeload.example.com/tar.gz' })
+      res.end()
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
+  })
+
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (typeof address !== 'object' || address == null) {
+    t.fail('Could not get server address')
+    return
+  }
+
+  const apiClient = api('ATOKEN')
+  const url = await resolveRedirect(
+    apiClient,
+    new URL(`http://localhost:${address.port}/tarball`),
+    false
+  )
+  t.is(url.href, 'https://codeload.example.com/tar.gz')
+
+  t.teardown(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+  )
 })
 
 test('calculate-download-checksum stream', async (t) => {

--- a/src/calculate-download-checksum.ts
+++ b/src/calculate-download-checksum.ts
@@ -2,8 +2,8 @@ import type { API } from './api.js'
 import { debug } from '@actions/core'
 import { URL } from 'url'
 import { createHash } from 'crypto'
-import { get as HTTP } from 'http'
-import { get as HTTPS, request } from 'https'
+import { get as HTTP, request as requestHTTP } from 'http'
+import { get as HTTPS, request as requestHTTPS } from 'https'
 
 interface Headers {
   [name: string]: string
@@ -38,14 +38,14 @@ type authInfo = {
   token: string
 }
 
-async function resolveRedirect(
+export async function resolveRedirect(
   apiClient: API,
   url: URL,
   asBinary: boolean
 ): Promise<URL> {
   const authInfo = (await apiClient.auth()) as authInfo
   return new Promise((resolve, reject) => {
-    const req = request(
+    const req = (url.protocol == 'https:' ? requestHTTPS : requestHTTP)(
       url,
       {
         method: 'HEAD',
@@ -57,7 +57,7 @@ async function resolveRedirect(
       },
       (res) => {
         res.resume() // ensure the response body has been fully read
-        if (res.statusCode == 302) {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
           const loc = res.headers['location']
           if (loc != null) {
             resolve(new URL(loc))

--- a/src/calculate-download-checksum.ts
+++ b/src/calculate-download-checksum.ts
@@ -38,6 +38,7 @@ type authInfo = {
   token: string
 }
 
+// Exported for tests.
 export async function resolveRedirect(
   apiClient: API,
   url: URL,
@@ -60,7 +61,8 @@ export async function resolveRedirect(
         if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
           const loc = res.headers['location']
           if (loc != null) {
-            resolve(new URL(loc))
+            // the base URL handles relative Location values
+            resolve(new URL(loc, url))
           } else {
             reject(
               new Error(`got HTTP ${res.statusCode} but no Location header`)


### PR DESCRIPTION
Fixes https://github.com/mislav/bump-homebrew-formula-action/issues/340

GitHub's tarball API (`HEAD /repos/{owner}/{repo}/tarball/{ref}`) started answering with HTTP 303 instead of 302 around 2026-05-16. `resolveRedirect` only accepted 302, so every run hitting that endpoint now fails with `Error: unexpected HTTP 303 response` before the formula is written.

This patch accepts any 3xx status carrying a `Location` header, matching the redirect handling `stream()` already uses a few lines above. It keeps rejecting 3xx responses without a `Location` header.

To make the new test exercise `resolveRedirect` against a local plain-HTTP server, the function now picks the `http`/`https` request implementation from the URL protocol (same pattern as `stream()`) and is exported for tests like `parseArchiveUrl`.

Hit in production by php/frankenphp's release workflow: https://github.com/php/frankenphp/actions/runs/26934983497